### PR TITLE
Support backoff policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ API specification: https://github.com/digipost/invoice-api-specification
 
 ## Download
 
-The last stable version is `1.2`, but a pending 2.0 release is available as `2.0-beta`.
+The last stable version is `1.2`, but a pending 2.0 release is available as `2.0-delta`.
 
 The library can be acquired from Maven Central Repository, using the dependency management tool of your choice.
 For Maven you can use the following dependency:

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,3 +2,6 @@ Jekyll Bootstrap Doc
 ====================
 
 http://mistic100.github.io/jekyll-bootstrap-doc
+
+https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/
+

--- a/docs/_v2_x/1_introduction.md
+++ b/docs/_v2_x/1_introduction.md
@@ -18,7 +18,7 @@ For Maven you can use the following dependency:
 <dependency>
     <groupId>no.digipost</groupId>
     <artifactId>digipost-useragreements-api-client-java</artifactId>
-    <version>2.0-beta</version>
+    <version>2.0-delta</version>
 </dependency>
 ```
 

--- a/docs/_v2_x/3_bank-account-numbers.md
+++ b/docs/_v2_x/3_bank-account-numbers.md
@@ -24,7 +24,7 @@ SenderId sender = SenderId.of(1234L);
 // The stream is made available immediately when the client starts receiving
 // the response, which is a rather long chunked http response.
 StreamingRateLimitedResponse<UserId> accountsResponse =
-    client.getAgreementUsers(sender, BANK_ACCOUNT_NUMBER_FOR_RECEIPTS);
+    client.getAgreementOwners(sender, BANK_ACCOUNT_NUMBER_FOR_RECEIPTS);
 
 
 // The processing of the stream should
@@ -32,9 +32,9 @@ StreamingRateLimitedResponse<UserId> accountsResponse =
 accountsResponse.map(UserId::serialize).forEach(this::persistAccountNumber);
 
 
-// Lastly, get the instant when you are allowed to do the request again, and
-// ensure that this
-Instant nextAllowedRequest = accountsResponse.getNestAllowedRequestTime();
+// Lastly, get the duration you must wait before you are allowed to do the request
+// again, and ensure that any subsequent request does not happen before.
+Duration delay = accountsResponse.getDelayUntilNextAllowedRequest();
 
 ...
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 	</parent>
 
 	<artifactId>digipost-useragreements-api-client-java</artifactId>
-	<version>2.0-delta</version>
+	<version>2.0-SNAPSHOT</version>
 
 	<name>Digipost User Agreements API Client</name>
 	<description>Java library for interacting with the Digipost UserAgreements API</description>
@@ -415,7 +415,7 @@
 		<connection>scm:git:git@github.com:digipost/digipost-useragreements-api-client-java.git</connection>
 		<developerConnection>scm:git:git@github.com:digipost/digipost-useragreements-api-client-java.git</developerConnection>
 		<url>scm:git:git@github.com:digipost/digipost-useragreements-api-client-java</url>
-		<tag>2.0-delta</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 	</parent>
 
 	<artifactId>digipost-useragreements-api-client-java</artifactId>
-	<version>2.0-SNAPSHOT</version>
+	<version>2.0-cgamma</version>
 
 	<name>Digipost User Agreements API Client</name>
 	<description>Java library for interacting with the Digipost UserAgreements API</description>
@@ -415,7 +415,7 @@
 		<connection>scm:git:git@github.com:digipost/digipost-useragreements-api-client-java.git</connection>
 		<developerConnection>scm:git:git@github.com:digipost/digipost-useragreements-api-client-java.git</developerConnection>
 		<url>scm:git:git@github.com:digipost/digipost-useragreements-api-client-java</url>
-		<tag>HEAD</tag>
+		<tag>2.0-cgamma</tag>
 	</scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,6 @@
 		<bouncycastle.version>1.54</bouncycastle.version>
 		<slf4j.version>1.7.25</slf4j.version>
 		<jaxb.version>2.2.7</jaxb.version>
-		<jsr173_api.version>1.0</jsr173_api.version>
 	</properties>
 
 	<dependencies>
@@ -89,7 +88,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>24.0-jre</version>
+			<version>24.1-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
@@ -133,7 +132,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>2.15.0</version>
+			<version>2.18.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -201,15 +200,15 @@
 				</plugin>
 				<plugin>
 					<artifactId>maven-clean-plugin</artifactId>
-					<version>3.0.0</version>
+					<version>3.1.0</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-dependency-plugin</artifactId>
-					<version>3.0.2</version>
+					<version>3.1.0</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>3.0.2</version>
+					<version>3.1.0</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-install-plugin</artifactId>
@@ -238,7 +237,7 @@
 				<plugin>
 					<groupId>com.github.siom79.japicmp</groupId>
 					<artifactId>japicmp-maven-plugin</artifactId>
-					<version>0.11.0</version>
+					<version>0.11.1</version>
 					<configuration>
 						<newVersion>
 							<file><path>${project.build.directory}/${project.build.finalName}.${project.packaging}</path></file>
@@ -348,6 +347,9 @@
 						<phase>test</phase>
 						<configuration>
 							<rules>
+								<requireMavenVersion>
+									<version>3.0</version>
+								</requireMavenVersion>
 								<bannedDependencies>
 									<excludes>
 										<exclude>*:*:*:jar:compile</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 	</parent>
 
 	<artifactId>digipost-useragreements-api-client-java</artifactId>
-	<version>2.0-SNAPSHOT</version>
+	<version>2.0-delta</version>
 
 	<name>Digipost User Agreements API Client</name>
 	<description>Java library for interacting with the Digipost UserAgreements API</description>
@@ -415,7 +415,7 @@
 		<connection>scm:git:git@github.com:digipost/digipost-useragreements-api-client-java.git</connection>
 		<developerConnection>scm:git:git@github.com:digipost/digipost-useragreements-api-client-java.git</developerConnection>
 		<url>scm:git:git@github.com:digipost/digipost-useragreements-api-client-java</url>
-		<tag>HEAD</tag>
+		<tag>2.0-delta</tag>
 	</scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 	</parent>
 
 	<artifactId>digipost-useragreements-api-client-java</artifactId>
-	<version>2.0-cgamma</version>
+	<version>2.0-SNAPSHOT</version>
 
 	<name>Digipost User Agreements API Client</name>
 	<description>Java library for interacting with the Digipost UserAgreements API</description>
@@ -415,7 +415,7 @@
 		<connection>scm:git:git@github.com:digipost/digipost-useragreements-api-client-java.git</connection>
 		<developerConnection>scm:git:git@github.com:digipost/digipost-useragreements-api-client-java.git</developerConnection>
 		<url>scm:git:git@github.com:digipost/digipost-useragreements-api-client-java</url>
-		<tag>2.0-cgamma</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 </project>

--- a/src/main/java/no/digipost/api/useragreements/client/AgreementOwners.java
+++ b/src/main/java/no/digipost/api/useragreements/client/AgreementOwners.java
@@ -22,32 +22,46 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlRootElement(name = "agreement-users")
-public class AgreementUsers {
+@XmlRootElement(name = "agreement-owners")
+public class AgreementOwners {
 
 	@XmlElement(name = "user-id")
 	@XmlJavaTypeAdapter(UserIdXmlAdapter.class)
-	private List<UserId> users;
+	private List<UserId> ids;
 
-	private AgreementUsers() {}
+	@XmlElement
+	private Instant nextRequestAllowedAt;
 
-	public AgreementUsers(final List<UserId> users) {
-		this.users = users;
+	public AgreementOwners(final List<UserId> users) {
+		this.ids = users;
 	}
 
-	public List<UserId> getUsers() {
-		if (users == null) {
-			users = new ArrayList<>();
+	public List<UserId> getIds() {
+		if (ids == null) {
+			ids = new ArrayList<>();
 		}
-		return users;
+		return ids;
+	}
+
+	public Optional<Instant> getNextRequestAllowedAt() {
+		return Optional.ofNullable(nextRequestAllowedAt);
 	}
 
 	@Override
 	public String toString() {
-		return users.toString();
+		return ids.toString();
 	}
+
+
+	// Used by JAXB
+	@SuppressWarnings("unused")
+	private AgreementOwners() {}
+
 }

--- a/src/main/java/no/digipost/api/useragreements/client/AgreementOwners.java
+++ b/src/main/java/no/digipost/api/useragreements/client/AgreementOwners.java
@@ -15,29 +15,28 @@
  */
 package no.digipost.api.useragreements.client;
 
-import no.digipost.api.useragreements.client.xml.UserIdXmlAdapter;
+import no.digipost.api.useragreements.client.response.WithNextAllowedRequestTime;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "agreement-owners")
-public class AgreementOwners {
+public class AgreementOwners implements WithNextAllowedRequestTime {
 
-	@XmlElement(name = "user-id")
-	@XmlJavaTypeAdapter(UserIdXmlAdapter.class)
+	@XmlElement(name = "id")
 	private List<UserId> ids;
 
-	@XmlElement
-	private Instant nextRequestAllowedAt;
+	@XmlElement(name = "next-allowed-request")
+	private Instant nextRequestAllowed;
 
 	public AgreementOwners(final List<UserId> users) {
 		this.ids = users;
@@ -50,8 +49,13 @@ public class AgreementOwners {
 		return ids;
 	}
 
-	public Optional<Instant> getNextRequestAllowedAt() {
-		return Optional.ofNullable(nextRequestAllowedAt);
+	public Stream<UserId> getIdsAsStream() {
+		return getIds().stream();
+	}
+
+	@Override
+	public Optional<Instant> getNextAllowedRequestTime() {
+		return Optional.ofNullable(nextRequestAllowed);
 	}
 
 	@Override

--- a/src/main/java/no/digipost/api/useragreements/client/AgreementOwners.java
+++ b/src/main/java/no/digipost/api/useragreements/client/AgreementOwners.java
@@ -15,14 +15,16 @@
  */
 package no.digipost.api.useragreements.client;
 
-import no.digipost.api.useragreements.client.response.WithNextAllowedRequestTime;
+import no.digipost.api.useragreements.client.response.WithDelayUntilNextAllowedRequestTime;
+import no.digipost.api.useragreements.client.xml.LongSecondsXmlAdapter;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
-import java.time.Instant;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -30,16 +32,18 @@ import java.util.stream.Stream;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "agreement-owners")
-public class AgreementOwners implements WithNextAllowedRequestTime {
+public class AgreementOwners implements WithDelayUntilNextAllowedRequestTime {
 
 	@XmlElement(name = "id")
 	private List<UserId> ids;
 
-	@XmlElement(name = "next-allowed-request")
-	private Instant nextRequestAllowed;
+	@XmlElement(name = "seconds-until-next-allowed-request")
+	@XmlJavaTypeAdapter(LongSecondsXmlAdapter.class)
+	private Duration delayUntilNextAllowedRequest;
 
-	public AgreementOwners(final List<UserId> users) {
+	public AgreementOwners(final List<UserId> users, Duration delayUntilNextAllowedRequest) {
 		this.ids = users;
+		this.delayUntilNextAllowedRequest = delayUntilNextAllowedRequest;
 	}
 
 	public List<UserId> getIds() {
@@ -54,8 +58,8 @@ public class AgreementOwners implements WithNextAllowedRequestTime {
 	}
 
 	@Override
-	public Optional<Instant> getNextAllowedRequestTime() {
-		return Optional.ofNullable(nextRequestAllowed);
+	public Optional<Duration> getDelayUntilNextAllowedRequest() {
+		return Optional.ofNullable(delayUntilNextAllowedRequest);
 	}
 
 	@Override

--- a/src/main/java/no/digipost/api/useragreements/client/ApiService.java
+++ b/src/main/java/no/digipost/api/useragreements/client/ApiService.java
@@ -40,9 +40,9 @@ import static java.time.Duration.ofMinutes;
 import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static no.digipost.api.useragreements.client.Headers.X_Digipost_UserId;
-import static no.digipost.api.useragreements.client.util.ResponseUtils.mapOkResponseOrThrowException;
-import static no.digipost.api.useragreements.client.util.ResponseUtils.unmarshallEntities;
-import static no.digipost.api.useragreements.client.util.ResponseUtils.unmarshallEntity;
+import static no.digipost.api.useragreements.client.response.ResponseUtils.mapOkResponseOrThrowException;
+import static no.digipost.api.useragreements.client.response.ResponseUtils.unmarshallEntities;
+import static no.digipost.api.useragreements.client.response.ResponseUtils.unmarshallEntity;
 import static no.digipost.cache2.inmemory.CacheConfig.expireAfterAccess;
 import static no.digipost.cache2.inmemory.CacheConfig.useSoftValues;
 

--- a/src/main/java/no/digipost/api/useragreements/client/ApiService.java
+++ b/src/main/java/no/digipost/api/useragreements/client/ApiService.java
@@ -151,9 +151,9 @@ public class ApiService {
 		return executeHttpRequest(newGetRequest(uriBuilder, requestTrackingId), handler);
 	}
 
-	public Stream<UserId> getAgreementUsers(final SenderId senderId, final AgreementType agreementType, final Boolean smsNotificationsEnabled, final String requestTrackingId) {
+	public Stream<UserId> getAgreementOwners(final SenderId senderId, final AgreementType agreementType, final Boolean smsNotificationsEnabled, final String requestTrackingId) {
 		URIBuilder uriBuilder = new URIBuilder(serviceEndpoint)
-				.setPath(userAgreementsPath(senderId) + "/agreement-users")
+				.setPath(userAgreementsPath(senderId) + "/agreement-owners")
 				.setParameter(AgreementType.QUERY_PARAM_NAME, agreementType.getType());
 		if (smsNotificationsEnabled != null) {
 			uriBuilder
@@ -165,7 +165,7 @@ public class ApiService {
 		CloseableHttpResponse response;
 		try {
 			response = httpClient.execute(request);
-			return mapOkResponseOrThrowException(response, r -> unmarshallEntities(r, AgreementUsers.class).flatMap(a -> a.getUsers().stream()));
+			return mapOkResponseOrThrowException(response, r -> unmarshallEntities(r, AgreementOwners.class).flatMap(a -> a.getIds().stream()));
 		} catch (IOException e) {
 			throw new RuntimeIOException(e.getMessage(), e);
 		}

--- a/src/main/java/no/digipost/api/useragreements/client/DigipostUserAgreementsClient.java
+++ b/src/main/java/no/digipost/api/useragreements/client/DigipostUserAgreementsClient.java
@@ -41,10 +41,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static no.digipost.api.useragreements.client.util.ResponseUtils.isOkResponse;
-import static no.digipost.api.useragreements.client.util.ResponseUtils.mapOkResponseOrThrowException;
-import static no.digipost.api.useragreements.client.util.ResponseUtils.readErrorEntity;
-import static no.digipost.api.useragreements.client.util.ResponseUtils.unmarshallEntity;
+import static no.digipost.api.useragreements.client.response.ResponseUtils.isOkResponse;
+import static no.digipost.api.useragreements.client.response.ResponseUtils.mapOkResponseOrThrowException;
+import static no.digipost.api.useragreements.client.response.ResponseUtils.readErrorEntity;
+import static no.digipost.api.useragreements.client.response.ResponseUtils.unmarshallEntity;
 
 /**
  * API client for managing Digipost documents on behalf of users

--- a/src/main/java/no/digipost/api/useragreements/client/DigipostUserAgreementsClient.java
+++ b/src/main/java/no/digipost/api/useragreements/client/DigipostUserAgreementsClient.java
@@ -20,6 +20,7 @@ import no.digipost.api.useragreements.client.filters.request.RequestDateIntercep
 import no.digipost.api.useragreements.client.filters.request.RequestSignatureInterceptor;
 import no.digipost.api.useragreements.client.filters.request.RequestUserAgentInterceptor;
 import no.digipost.api.useragreements.client.filters.response.ResponseDateInterceptor;
+import no.digipost.api.useragreements.client.response.StreamingRateLimitedResponse;
 import no.digipost.api.useragreements.client.security.CryptoUtil;
 import no.digipost.api.useragreements.client.security.PrivateKeySigner;
 import no.digipost.http.client3.DigipostHttpClientFactory;
@@ -39,7 +40,6 @@ import java.security.PrivateKey;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import static no.digipost.api.useragreements.client.util.ResponseUtils.isOkResponse;
 import static no.digipost.api.useragreements.client.util.ResponseUtils.mapOkResponseOrThrowException;
@@ -185,15 +185,15 @@ public class DigipostUserAgreementsClient {
 		return apiService.getDocumentContent(senderId, agreementType, documentId, requestTrackingId, singleJaxbEntityHandler(DocumentContent.class));
 	}
 
-	public Stream<UserId> getAgreementOwners(final SenderId senderId, final AgreementType agreementType) {
+	public StreamingRateLimitedResponse<UserId> getAgreementOwners(final SenderId senderId, final AgreementType agreementType) {
 		return getAgreementOwners(senderId, agreementType, null);
 	}
 
-	public Stream<UserId> getAgreementOwners(final SenderId senderId, final AgreementType agreementType, final Boolean smsNotificationEnabled) {
+	public StreamingRateLimitedResponse<UserId> getAgreementOwners(final SenderId senderId, final AgreementType agreementType, final Boolean smsNotificationEnabled) {
 		return getAgreementOwners(senderId, agreementType, smsNotificationEnabled, null);
 	}
 
-	public Stream<UserId> getAgreementOwners(final SenderId senderId, final AgreementType agreementType, final Boolean smsNotificationEnabled, final String requestTrackingId) {
+	public StreamingRateLimitedResponse<UserId> getAgreementOwners(final SenderId senderId, final AgreementType agreementType, final Boolean smsNotificationEnabled, final String requestTrackingId) {
 		Objects.requireNonNull(senderId, "senderId cannot be null");
 		Objects.requireNonNull(agreementType, "agreementType cannot be null");
 		return apiService.getAgreementOwners(senderId, agreementType, smsNotificationEnabled, requestTrackingId);

--- a/src/main/java/no/digipost/api/useragreements/client/DigipostUserAgreementsClient.java
+++ b/src/main/java/no/digipost/api/useragreements/client/DigipostUserAgreementsClient.java
@@ -185,18 +185,18 @@ public class DigipostUserAgreementsClient {
 		return apiService.getDocumentContent(senderId, agreementType, documentId, requestTrackingId, singleJaxbEntityHandler(DocumentContent.class));
 	}
 
-	public Stream<UserId> getAgreementUsers(final SenderId senderId, final AgreementType agreementType) {
-		return getAgreementUsers(senderId, agreementType, null);
+	public Stream<UserId> getAgreementOwners(final SenderId senderId, final AgreementType agreementType) {
+		return getAgreementOwners(senderId, agreementType, null);
 	}
 
-	public Stream<UserId> getAgreementUsers(final SenderId senderId, final AgreementType agreementType, final Boolean smsNotificationEnabled) {
-		return getAgreementUsers(senderId, agreementType, smsNotificationEnabled, null);
+	public Stream<UserId> getAgreementOwners(final SenderId senderId, final AgreementType agreementType, final Boolean smsNotificationEnabled) {
+		return getAgreementOwners(senderId, agreementType, smsNotificationEnabled, null);
 	}
 
-	public Stream<UserId> getAgreementUsers(final SenderId senderId, final AgreementType agreementType, final Boolean smsNotificationEnabled, final String requestTrackingId) {
+	public Stream<UserId> getAgreementOwners(final SenderId senderId, final AgreementType agreementType, final Boolean smsNotificationEnabled, final String requestTrackingId) {
 		Objects.requireNonNull(senderId, "senderId cannot be null");
 		Objects.requireNonNull(agreementType, "agreementType cannot be null");
-		return apiService.getAgreementUsers(senderId, agreementType, smsNotificationEnabled, requestTrackingId);
+		return apiService.getAgreementOwners(senderId, agreementType, smsNotificationEnabled, requestTrackingId);
 	}
 
 	private ResponseHandler<Void> voidOkHandler() {

--- a/src/main/java/no/digipost/api/useragreements/client/ErrorCode.java
+++ b/src/main/java/no/digipost/api/useragreements/client/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
 	IO_EXCEPTION,
 	NO_ENTITY,
 	MULTIPLE_ENTITIES,
+	MISSING_NEXT_ALLOWED_REQUEST_TIME,
 	GENERAL_ERROR;
 
 	public static ErrorCode parse(final String error) {

--- a/src/main/java/no/digipost/api/useragreements/client/Headers.java
+++ b/src/main/java/no/digipost/api/useragreements/client/Headers.java
@@ -16,12 +16,29 @@
 package no.digipost.api.useragreements.client;
 
 public final class Headers {
-	public static final String X_Digipost_Prefix = "X-Digipost-";
 
+	private static final String X_Digipost_Prefix = "X-Digipost-";
+
+	/**
+	 * X-Digipost-Signature (Digipost-specific header)
+	 */
 	public static final String X_Digipost_Signature = X_Digipost_Prefix + "Signature";
+
+	/**
+	 * X-Digipost-UserId (Digipost-specific header)
+	 */
 	public static final String X_Digipost_UserId = X_Digipost_Prefix + "UserId";
 
+	/**
+	 * Content-MD5
+	 *
+	 * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.15">RFC 2616 section 14.15</a>
+	 */
 	public static final String Content_MD5 = "Content-MD5";
+
+	/**
+	 * X-Content-SHA256 (Digipost-specific header)
+	 */
 	public static final String X_Content_SHA256 = "X-Content-SHA256";
 
 }

--- a/src/main/java/no/digipost/api/useragreements/client/Headers.java
+++ b/src/main/java/no/digipost/api/useragreements/client/Headers.java
@@ -41,4 +41,11 @@ public final class Headers {
 	 */
 	public static final String X_Content_SHA256 = "X-Content-SHA256";
 
+	/**
+	 * Retry-After
+	 *
+	 * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.37">RFC 2616 section 14.37</a>
+	 */
+	public static final String Retry_After = "Retry-After";
+
 }

--- a/src/main/java/no/digipost/api/useragreements/client/Invoice.java
+++ b/src/main/java/no/digipost/api/useragreements/client/Invoice.java
@@ -15,7 +15,6 @@
  */
 package no.digipost.api.useragreements.client;
 
-import no.digipost.api.useragreements.client.xml.DateXmlAdapter;
 import no.digipost.api.useragreements.client.xml.InvoiceStatusXmlAdapter;
 import no.digipost.api.useragreements.client.xml.KidXmlAdapter;
 
@@ -41,7 +40,6 @@ public class Invoice {
 	@XmlElement
 	private String account;
 	@XmlElement(name = "due-date", type = String.class)
-	@XmlJavaTypeAdapter(DateXmlAdapter.class)
 	@XmlSchemaType(name = "date")
 	private LocalDate dueDate;
 	@XmlElement

--- a/src/main/java/no/digipost/api/useragreements/client/TooManyRequestsException.java
+++ b/src/main/java/no/digipost/api/useragreements/client/TooManyRequestsException.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.useragreements.client;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static no.digipost.api.useragreements.client.ErrorCode.CLIENT_TECHNICAL_ERROR;
+
+public class TooManyRequestsException extends UserAgreementsApiException {
+
+	private final Instant nextAllowedRequest;
+
+	public TooManyRequestsException(Optional<Instant> nextAllowedRequest) {
+		super(CLIENT_TECHNICAL_ERROR, "This API resource has a rate limiter, and you are accessing it more frequent than it allows. " +	nextAllowedRequest
+				.map(instant -> "Next request should be done not earlier than " + instant + ".")
+				.orElse("There is no indication when you may try again."));
+		this.nextAllowedRequest = nextAllowedRequest.orElse(null);
+	}
+
+	public Optional<Instant> getNextAllowedRequest() {
+		return Optional.ofNullable(nextAllowedRequest);
+	}
+
+}

--- a/src/main/java/no/digipost/api/useragreements/client/package-info.java
+++ b/src/main/java/no/digipost/api/useragreements/client/package-info.java
@@ -13,5 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@javax.xml.bind.annotation.XmlSchema(namespace = "http://api.digipost.no/user/schema/v1", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
+@XmlSchema(namespace = "http://api.digipost.no/user/schema/v1", elementFormDefault = QUALIFIED)
+@XmlJavaTypeAdapters({
+		@XmlJavaTypeAdapter(type = Instant.class, value = InstantXmlAdapter.class),
+		@XmlJavaTypeAdapter(type = LocalDate.class, value = DateXmlAdapter.class),
+		@XmlJavaTypeAdapter(type = UserId.class, value = UserIdXmlAdapter.class)
+})
 package no.digipost.api.useragreements.client;
+
+import no.digipost.api.useragreements.client.xml.DateXmlAdapter;
+import no.digipost.api.useragreements.client.xml.InstantXmlAdapter;
+import no.digipost.api.useragreements.client.xml.UserIdXmlAdapter;
+
+import javax.xml.bind.annotation.XmlSchema;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapters;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+import static javax.xml.bind.annotation.XmlNsForm.QUALIFIED;

--- a/src/main/java/no/digipost/api/useragreements/client/response/NextAllowedRequestTimeNotFoundException.java
+++ b/src/main/java/no/digipost/api/useragreements/client/response/NextAllowedRequestTimeNotFoundException.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.useragreements.client.response;
+
+import no.digipost.api.useragreements.client.ErrorCode;
+import no.digipost.api.useragreements.client.UserAgreementsApiException;
+
+public class NextAllowedRequestTimeNotFoundException extends UserAgreementsApiException {
+
+	public NextAllowedRequestTimeNotFoundException() {
+		super(ErrorCode.MISSING_NEXT_ALLOWED_REQUEST_TIME,
+				"The instant for next allowed request has not been acquired yet. " +
+				"The response must be consumed before trying to get this value.");
+	}
+}

--- a/src/main/java/no/digipost/api/useragreements/client/response/ResponseUtils.java
+++ b/src/main/java/no/digipost/api/useragreements/client/response/ResponseUtils.java
@@ -13,13 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package no.digipost.api.useragreements.client.util;
+package no.digipost.api.useragreements.client.response;
 
 import no.digipost.api.useragreements.client.Error;
 import no.digipost.api.useragreements.client.ErrorCode;
 import no.digipost.api.useragreements.client.Headers;
 import no.digipost.api.useragreements.client.RuntimeIOException;
-import no.digipost.api.useragreements.client.TooManyRequestsException;
 import no.digipost.api.useragreements.client.UnexpectedResponseException;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;

--- a/src/main/java/no/digipost/api/useragreements/client/response/StreamingRateLimitedResponse.java
+++ b/src/main/java/no/digipost/api/useragreements/client/response/StreamingRateLimitedResponse.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.useragreements.client.response;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+public class StreamingRateLimitedResponse<T> {
+
+	@FunctionalInterface
+	public static interface ResponseElementHandler<T> {
+		void handle(T id) throws Exception;
+	}
+
+	private final Stream<T> elements;
+	private final AtomicBoolean consumed = new AtomicBoolean(false);
+	private final Supplier<Instant> nextAllowedRequest;
+
+	public <S extends WithNextAllowedRequestTime> StreamingRateLimitedResponse(Stream<S> responseElements, Function<? super S, Stream<T>> flatMapper) {
+		this(responseElements, new DeferredNextAllowedRequest(), flatMapper);
+	}
+
+	private <S extends WithNextAllowedRequestTime> StreamingRateLimitedResponse(Stream<S> responseElements, DeferredNextAllowedRequest deferredNextAllowedRequest, Function<? super S, Stream<T>> flatMapper) {
+		this(responseElements.flatMap(elements -> {
+			deferredNextAllowedRequest.register(elements);
+			return flatMapper.apply(elements);
+		}), deferredNextAllowedRequest);
+	}
+
+	public StreamingRateLimitedResponse(Stream<T> elements, Supplier<Instant> nextAllowedRequest) {
+		this.elements = elements;
+		this.nextAllowedRequest = nextAllowedRequest;
+	}
+
+	public <R> StreamingRateLimitedResponse<R> map(Function<? super T, R> mapper) {
+		return new StreamingRateLimitedResponse<>(asStream().map(mapper), nextAllowedRequest);
+	}
+
+	public <R> StreamingRateLimitedResponse<R> flatMap(Function<? super T, Stream<R>> mapper) {
+		return new StreamingRateLimitedResponse<>(asStream().flatMap(mapper), nextAllowedRequest);
+	}
+
+	public void forEach(ResponseElementHandler<T> handler) {
+		try (Stream<T> autoClosed = asStream()) {
+			elements.forEach(id -> {
+				try {
+					handler.handle(id);
+				} catch (RuntimeException e) {
+					throw e;
+				} catch (Exception e) {
+					throw new RuntimeException(e.getClass().getSimpleName() + ": '" + e.getMessage() + "'", e);
+				}
+			});
+		}
+	}
+
+	public Instant getNextAllowedRequest() {
+		return nextAllowedRequest.get();
+	}
+
+	/**
+	 * Expose the retrieved elements as a Java {@link Stream}. Using this method
+	 * requires proper resource handling and the stream <strong>must</strong>
+	 * be {@link Stream#close() closed} after it has been consumed.
+	 * <p>
+	 * Prefer {@link #forEach(ResponseElementHandler)} over this method.
+	 *
+	 * @return the elements of the response as a Stream.
+	 */
+	public Stream<T> asStream() {
+		switchToConsumedState();
+		return elements;
+	}
+
+	private void switchToConsumedState() {
+		if (consumed.getAndSet(true)) {
+			throw new IllegalStateException("This response is already consumed, and the invoked operation is illegal.");
+		}
+
+	}
+
+
+	private static final class DeferredNextAllowedRequest implements Supplier<Instant> {
+		private volatile Instant nextAllowedRequest;
+
+		void register(WithNextAllowedRequestTime element) {
+			element.getNextAllowedRequestTime().ifPresent(nextAllowedRequestTime -> this.nextAllowedRequest = nextAllowedRequestTime);
+		}
+
+		@Override
+		public Instant get() {
+			if (nextAllowedRequest == null) {
+				throw new IllegalStateException(
+						"The instant for next allowed request has not been acquired yet. The response must be consumed before trying to get this value.");
+			}
+			return nextAllowedRequest;
+		}
+	}
+}

--- a/src/main/java/no/digipost/api/useragreements/client/response/TooManyRequestsException.java
+++ b/src/main/java/no/digipost/api/useragreements/client/response/TooManyRequestsException.java
@@ -13,14 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package no.digipost.api.useragreements.client;
+package no.digipost.api.useragreements.client.response;
+
+import no.digipost.api.useragreements.client.UserAgreementsApiException;
 
 import java.time.Instant;
 import java.util.Optional;
 
 import static no.digipost.api.useragreements.client.ErrorCode.CLIENT_TECHNICAL_ERROR;
 
-public class TooManyRequestsException extends UserAgreementsApiException {
+public class TooManyRequestsException extends UserAgreementsApiException implements WithNextAllowedRequestTime {
 
 	private final Instant nextAllowedRequest;
 
@@ -31,7 +33,8 @@ public class TooManyRequestsException extends UserAgreementsApiException {
 		this.nextAllowedRequest = nextAllowedRequest.orElse(null);
 	}
 
-	public Optional<Instant> getNextAllowedRequest() {
+	@Override
+	public Optional<Instant> getNextAllowedRequestTime() {
 		return Optional.ofNullable(nextAllowedRequest);
 	}
 

--- a/src/main/java/no/digipost/api/useragreements/client/response/TooManyRequestsException.java
+++ b/src/main/java/no/digipost/api/useragreements/client/response/TooManyRequestsException.java
@@ -17,25 +17,30 @@ package no.digipost.api.useragreements.client.response;
 
 import no.digipost.api.useragreements.client.UserAgreementsApiException;
 
-import java.time.Instant;
+import java.time.Duration;
 import java.util.Optional;
 
 import static no.digipost.api.useragreements.client.ErrorCode.CLIENT_TECHNICAL_ERROR;
 
-public class TooManyRequestsException extends UserAgreementsApiException implements WithNextAllowedRequestTime {
+public class TooManyRequestsException extends UserAgreementsApiException implements WithDelayUntilNextAllowedRequestTime {
 
-	private final Instant nextAllowedRequest;
+	private final Duration delayUntilNextAllowedRequest;
 
-	public TooManyRequestsException(Optional<Instant> nextAllowedRequest) {
-		super(CLIENT_TECHNICAL_ERROR, "This API resource has a rate limiter, and you are accessing it more frequent than it allows. " +	nextAllowedRequest
-				.map(instant -> "Next request should be done not earlier than " + instant + ".")
-				.orElse("There is no indication when you may try again."));
-		this.nextAllowedRequest = nextAllowedRequest.orElse(null);
+	public TooManyRequestsException() {
+		this(null);
+	}
+
+	public TooManyRequestsException(Duration delayUntilNextAllowed) {
+		super(CLIENT_TECHNICAL_ERROR,
+				"This API resource has a rate limiter, and you are accessing it more frequent than it allows. " +
+				(delayUntilNextAllowed != null ? "Next request should be done not earlier than " + delayUntilNextAllowed.getSeconds() + " seconds from now."
+						                              : "There is no indication when you may try again."));
+		this.delayUntilNextAllowedRequest = delayUntilNextAllowed;
 	}
 
 	@Override
-	public Optional<Instant> getNextAllowedRequestTime() {
-		return Optional.ofNullable(nextAllowedRequest);
+	public Optional<Duration> getDelayUntilNextAllowedRequest() {
+		return Optional.ofNullable(delayUntilNextAllowedRequest);
 	}
 
 }

--- a/src/main/java/no/digipost/api/useragreements/client/response/WithDelayUntilNextAllowedRequestTime.java
+++ b/src/main/java/no/digipost/api/useragreements/client/response/WithDelayUntilNextAllowedRequestTime.java
@@ -15,11 +15,11 @@
  */
 package no.digipost.api.useragreements.client.response;
 
-import java.time.Instant;
+import java.time.Duration;
 import java.util.Optional;
 
-public interface WithNextAllowedRequestTime {
+public interface WithDelayUntilNextAllowedRequestTime {
 
-	Optional<Instant> getNextAllowedRequestTime();
+	Optional<Duration> getDelayUntilNextAllowedRequest();
 
 }

--- a/src/main/java/no/digipost/api/useragreements/client/response/WithNextAllowedRequestTime.java
+++ b/src/main/java/no/digipost/api/useragreements/client/response/WithNextAllowedRequestTime.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.useragreements.client.response;
+
+import java.time.Instant;
+import java.util.Optional;
+
+public interface WithNextAllowedRequestTime {
+
+	Optional<Instant> getNextAllowedRequestTime();
+
+}

--- a/src/main/java/no/digipost/api/useragreements/client/util/ResponseUtils.java
+++ b/src/main/java/no/digipost/api/useragreements/client/util/ResponseUtils.java
@@ -17,7 +17,9 @@ package no.digipost.api.useragreements.client.util;
 
 import no.digipost.api.useragreements.client.Error;
 import no.digipost.api.useragreements.client.ErrorCode;
+import no.digipost.api.useragreements.client.Headers;
 import no.digipost.api.useragreements.client.RuntimeIOException;
+import no.digipost.api.useragreements.client.TooManyRequestsException;
 import no.digipost.api.useragreements.client.UnexpectedResponseException;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -33,6 +35,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.time.Instant;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.Scanner;
@@ -41,6 +44,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 import static java.util.Spliterator.IMMUTABLE;
 import static java.util.Spliterators.spliteratorUnknownSize;
 import static java.util.stream.StreamSupport.stream;
@@ -58,6 +62,11 @@ public final class ResponseUtils {
 		final StatusLine statusLine = response.getStatusLine();
 		if (isOkResponse(statusLine.getStatusCode())) {
 			return okResponseMapper.apply(response);
+		} else if (statusLine.getStatusCode() == 429) { // Too Many Requests
+			Optional<Instant> nextAllowedRequest = Optional.ofNullable(response.getFirstHeader(Headers.Retry_After))
+				.flatMap(h -> Optional.ofNullable(h.getValue()))
+				.map(retryAfterValue -> RFC_1123_DATE_TIME.parse(retryAfterValue, Instant::from));
+			throw new TooManyRequestsException(nextAllowedRequest);
 		} else {
 			throw new UnexpectedResponseException(statusLine, readErrorEntity(response));
 		}

--- a/src/main/java/no/digipost/api/useragreements/client/xml/InstantXmlAdapter.java
+++ b/src/main/java/no/digipost/api/useragreements/client/xml/InstantXmlAdapter.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.useragreements.client.xml;
+
+import javax.xml.bind.DatatypeConverter;
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+import java.time.Instant;
+
+import static java.time.ZoneOffset.UTC;
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+public class InstantXmlAdapter extends XmlAdapter<String, Instant> {
+
+	@Override
+	public Instant unmarshal(String value) {
+		return DatatypeConverter.parseDate(value).toInstant();
+	}
+
+	@Override
+	public String marshal(Instant instant) {
+		return ISO_OFFSET_DATE_TIME.format(instant.atZone(UTC));
+	}
+}

--- a/src/main/java/no/digipost/api/useragreements/client/xml/LongSecondsXmlAdapter.java
+++ b/src/main/java/no/digipost/api/useragreements/client/xml/LongSecondsXmlAdapter.java
@@ -13,16 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package no.digipost.api.useragreements.client.response;
+package no.digipost.api.useragreements.client.xml;
 
-import no.digipost.api.useragreements.client.ErrorCode;
-import no.digipost.api.useragreements.client.UserAgreementsApiException;
+import javax.xml.bind.annotation.adapters.XmlAdapter;
 
-public class NextAllowedRequestTimeNotFoundException extends UserAgreementsApiException {
+import java.time.Duration;
 
-	public NextAllowedRequestTimeNotFoundException() {
-		super(ErrorCode.MISSING_NEXT_ALLOWED_REQUEST_TIME,
-				"The duration to wait until next allowed request has not been acquired yet. " +
-				"The response must be consumed before trying to get this value.");
+public class LongSecondsXmlAdapter extends XmlAdapter<Long, Duration> {
+
+	@Override
+	public Duration unmarshal(Long seconds) {
+		return seconds != null ? Duration.ofSeconds(seconds) : null;
 	}
+
+	@Override
+	public Long marshal(Duration duration) {
+		return duration != null ? duration.getSeconds() : null;
+	}
+
 }

--- a/src/test/java/no/digipost/api/useragreements/client/MarshallingTest.java
+++ b/src/test/java/no/digipost/api/useragreements/client/MarshallingTest.java
@@ -15,7 +15,6 @@
  */
 package no.digipost.api.useragreements.client;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,9 +24,14 @@ import javax.xml.bind.JAXB;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.URISyntaxException;
-import java.util.Collections;
+import java.time.Duration;
+import java.util.List;
 
+import static co.unruly.matchers.OptionalMatchers.contains;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 
 public class MarshallingTest {
 
@@ -41,15 +45,28 @@ public class MarshallingTest {
 		JAXB.marshal(agreement, xml);
 		log.debug(xml.toString());
 		final Agreement unmarshal = JAXB.unmarshal(new StringReader(xml.toString()), Agreement.class);
-		Assert.assertThat(unmarshal.getUserId(), is(userId));
+		assertThat(unmarshal.getUserId(), is(userId));
 	}
 
 	@Test
 	public void shouldMarshallUnmarshallAgreements() {
 		final StringWriter xml = new StringWriter();
-		final Agreements agreements = new Agreements(Collections.singletonList(Agreement.createInvoiceBankAgreement(UserId.of("01017012345"), true)));
+		final Agreements agreements = new Agreements(singletonList(Agreement.createInvoiceBankAgreement(UserId.of("01017012345"), true)));
 		JAXB.marshal(agreements, xml);
 		log.debug(xml.toString());
 		JAXB.unmarshal(new StringReader(xml.toString()), Agreements.class);
+	}
+
+	@Test
+	public void shouldMarshallUnmarshallAgreementOwners() {
+		StringWriter xml = new StringWriter();
+		List<UserId> accountNumbers = asList(UserId.of("180020111111"), UserId.of("180020111112"));
+		Duration delay = Duration.ofSeconds(42);
+		AgreementOwners owners = new AgreementOwners(accountNumbers, delay);
+		JAXB.marshal(owners, xml);
+		log.debug(xml.toString());
+		AgreementOwners unmarshalled = JAXB.unmarshal(new StringReader(xml.toString()), AgreementOwners.class);
+		assertThat(unmarshalled.getDelayUntilNextAllowedRequest(), contains(delay));
+		assertThat(unmarshalled.getIds(), is(accountNumbers));
 	}
 }

--- a/src/test/java/no/digipost/api/useragreements/client/response/ResponseUtilsTest.java
+++ b/src/test/java/no/digipost/api/useragreements/client/response/ResponseUtilsTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.useragreements.client.response;
+
+import no.digipost.api.useragreements.client.Headers;
+import org.apache.http.HttpResponse;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
+import org.junit.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static co.unruly.matchers.Java8Matchers.where;
+import static co.unruly.matchers.OptionalMatchers.contains;
+import static co.unruly.matchers.OptionalMatchers.empty;
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Stream.concat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class ResponseUtilsTest {
+
+	@Test
+	public void parsesSecondsFromRetryAfterHeaderIn429Response() {
+		HttpResponse tooManyRequestsErrorResponse = tooManyRequestsResponseWithRetryAfter("10");
+		try {
+			ResponseUtils.mapOkResponseOrThrowException(tooManyRequestsErrorResponse, Function.identity());
+			fail("should have thrown exception");
+		} catch (TooManyRequestsException tooManyRequests) {
+			assertThat(tooManyRequests, where(TooManyRequestsException::getDelayUntilNextAllowedRequest, contains(Duration.ofSeconds(10))));
+			assertThat(tooManyRequests, where(Throwable::getSuppressed, emptyArray()));
+		}
+	}
+
+	@Test
+	public void parsesDateFromRetryAfterHeader() {
+		Clock clock = Clock.fixed(Instant.now().truncatedTo(SECONDS), ZoneOffset.UTC);
+		HttpResponse tooManyRequestsErrorResponse = tooManyRequestsResponseWithRetryAfter(RFC_1123_DATE_TIME.format(ZonedDateTime.now(clock).plusSeconds(42)));
+
+		Optional<Duration> parsedDuration = ResponseUtils.parseDelayDurationOfRetryAfterHeader(tooManyRequestsErrorResponse, clock);
+		assertThat(parsedDuration, contains(Duration.ofSeconds(42)));
+	}
+
+
+	@Test
+	public void malformedRetryAfterHeaderIncludesSuppressedException() {
+		HttpResponse tooManyRequestsErrorResponse = tooManyRequestsResponseWithRetryAfter("does not compute");
+		try {
+			ResponseUtils.mapOkResponseOrThrowException(tooManyRequestsErrorResponse, Function.identity());
+			fail("should have thrown exception");
+		} catch (TooManyRequestsException tooManyRequests) {
+			assertThat(tooManyRequests, where(TooManyRequestsException::getDelayUntilNextAllowedRequest, empty()));
+			List<Throwable> allSuppressed = Stream.of(tooManyRequests.getSuppressed()).flatMap(suppressed -> concat(Stream.of(suppressed), Stream.of(suppressed.getSuppressed()))).collect(toList());
+			assertThat(allSuppressed, containsInAnyOrder(instanceOf(DateTimeParseException.class), instanceOf(NumberFormatException.class)));
+		}
+	}
+
+
+	private static HttpResponse tooManyRequestsResponseWithRetryAfter(String retryAfterValue) {
+		HttpResponse tooManyRequestsErrorResponse = new BasicHttpResponse(new BasicStatusLine(new ProtocolVersion("http", 1, 1), 429, "Too Many Requests"));
+		tooManyRequestsErrorResponse.addHeader(Headers.Retry_After, retryAfterValue);
+		return tooManyRequestsErrorResponse;
+	}
+}

--- a/src/test/java/no/digipost/api/useragreements/client/response/StreamingRateLimitedResponseTest.java
+++ b/src/test/java/no/digipost/api/useragreements/client/response/StreamingRateLimitedResponseTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.api.useragreements.client.response;
+
+import no.digipost.api.useragreements.client.response.StreamingRateLimitedResponse;
+import no.digipost.api.useragreements.client.response.WithNextAllowedRequestTime;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static co.unruly.matchers.Java8Matchers.where;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class StreamingRateLimitedResponseTest {
+
+	static final class ResponseElements implements WithNextAllowedRequestTime {
+
+		private final int amount;
+		private final Optional<Instant> nextAllowedRequest;
+
+		public ResponseElements(int amount) {
+			this(amount, null);
+		}
+
+		public ResponseElements(int amount, Instant nextAllowedRequest) {
+			this.amount = amount;
+			this.nextAllowedRequest = Optional.ofNullable(nextAllowedRequest);
+		}
+
+		public Stream<Integer> elements() {
+			return IntStream.range(0, amount).boxed();
+		}
+
+		@Override
+		public Optional<Instant> getNextAllowedRequestTime() {
+			return nextAllowedRequest;
+		}
+	}
+
+	@Test
+	public void populatesNextAllowedRequestTimeWhenConsumingStream() {
+		Instant nextAllowedRequest = Instant.now().plus(Duration.ofMinutes(10));
+		StreamingRateLimitedResponse<String> response = new StreamingRateLimitedResponse<>(Stream.of(new ResponseElements(1), new ResponseElements(2, nextAllowedRequest)), ResponseElements::elements)
+				.map(String::valueOf);
+		try (Stream<String> responseStrings = response.asStream()) {
+			assertThat(responseStrings.collect(toList()), contains("0", "0", "1"));
+		}
+		assertThat(response, where(StreamingRateLimitedResponse::getNextAllowedRequest, is(nextAllowedRequest)));
+	}
+}

--- a/src/test/java/no/digipost/api/useragreements/client/response/StreamingRateLimitedResponseTest.java
+++ b/src/test/java/no/digipost/api/useragreements/client/response/StreamingRateLimitedResponseTest.java
@@ -15,9 +15,9 @@
  */
 package no.digipost.api.useragreements.client.response;
 
-import no.digipost.api.useragreements.client.response.StreamingRateLimitedResponse;
-import no.digipost.api.useragreements.client.response.WithNextAllowedRequestTime;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -57,6 +57,9 @@ public class StreamingRateLimitedResponseTest {
 		}
 	}
 
+	@Rule
+	public final ExpectedException expectedException = ExpectedException.none();
+
 	@Test
 	public void populatesNextAllowedRequestTimeWhenConsumingStream() {
 		Instant nextAllowedRequest = Instant.now().plus(Duration.ofMinutes(10));
@@ -66,5 +69,12 @@ public class StreamingRateLimitedResponseTest {
 			assertThat(responseStrings.collect(toList()), contains("0", "0", "1"));
 		}
 		assertThat(response, where(StreamingRateLimitedResponse::getNextAllowedRequest, is(nextAllowedRequest)));
+	}
+
+	@Test
+	public void throwsExceptionIfNextAllowedRequestTimeNotPopuatedYet() {
+		StreamingRateLimitedResponse<?> response = new StreamingRateLimitedResponse<>(Stream.empty(), () -> null);
+		expectedException.expect(NextAllowedRequestTimeNotFoundException.class);
+		response.getNextAllowedRequest();
 	}
 }


### PR DESCRIPTION
Add support for getting the instant for when the next allowed request is allowed to be performed. Wraps the streaming response in a `StreamingRateLimitedResponse` which handles capturing this instant from the end of the streaming response.

<img width="807" alt="screen shot 2018-04-24 at 14 12 22" src="https://user-images.githubusercontent.com/174823/39186073-8f51eebc-47c9-11e8-8e87-272fb589510e.png">
