### PR TITLE
Oppdater v3-dokumentasjon til å si 3.0.0 i stedet for 2.0

### DIFF
--- a/docs/_v3_x/1_introduction.md
+++ b/docs/_v3_x/1_introduction.md
@@ -18,7 +18,7 @@ For Maven you can use the following dependency:
 <dependency>
     <groupId>no.digipost</groupId>
     <artifactId>digipost-useragreements-api-client-java</artifactId>
-    <version>2.0-delta</version>
+    <version>3.0.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Skal release 3.0.0 i nær fremtid, og da bør dokumentasjonen referere til riktig versjon.