### PR TITLE
Bump guava dependency to 32.0.1

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -28,7 +28,7 @@ This software includes third party software subject to the following licenses:
   Guava ListenableFuture only under The Apache Software License, Version 2.0
   Guava: Google Core Libraries for Java under Apache License, Version 2.0
   istack common utility code runtime under Eclipse Distribution License - v 1.0
-  J2ObjC Annotations under The Apache Software License, Version 2.0
+  J2ObjC Annotations under Apache License, Version 2.0
   jakarta.xml.bind-api under Eclipse Distribution License - v 1.0
   JavaBeans Activation Framework API jar under EDL 1.0
   JAXB Runtime under Eclipse Distribution License - v 1.0

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>31.1-jre</version>
+			<version>32.0.1-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Previous versions had a vulnerability (CVE-2023-2976)