### PR TITLE
Bump ruby deps og oppdater Gemfile til Ruby > 3.0.0

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 require 'json'
 require 'open-uri'
-versions = JSON.parse(open('https://pages.github.com/versions.json').read)
+
+versions = JSON.parse(OpenURI.open_uri('https://pages.github.com/versions.json').read)
 
 gem 'github-pages', versions['github-pages'], group: :jekyll_plugins
+gem "webrick", "~> 1.8"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,22 +1,32 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.4.3)
+    activesupport (7.1.2)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.4)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
-    commonmarker (0.23.9)
+    commonmarker (0.23.10)
     concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
     dnsruby (1.70.0)
       simpleidn (~> 0.2.1)
+    drb (2.2.0)
+      ruby2_keywords
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -86,7 +96,7 @@ GEM
       activesupport (>= 2)
       nokogiri (>= 1.4)
     http_parser.rb (0.8.0)
-    i18n (1.12.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     jekyll (3.9.3)
       addressable (~> 2.4)
@@ -209,7 +219,8 @@ GEM
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    minitest (5.18.0)
+    minitest (5.20.0)
+    mutex_m (0.2.0)
     nokogiri (1.14.3-x86_64-darwin)
       racc (~> 1.4)
     octokit (4.25.1)
@@ -247,12 +258,14 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
+    webrick (1.8.1)
 
 PLATFORMS
   x86_64-darwin-21
 
 DEPENDENCIES
   github-pages (= 228)
+  webrick (~> 1.8)
 
 BUNDLED WITH
    2.4.12


### PR DESCRIPTION
I Gemfile henter vi fra en ekstern url. Tidligere versjoner av ruby (< 3.0) var det støttet å bruke Kernel.open(), men pga sikkerhetsrisiko er det deprecated i Ruby 3.0. Har skrevet om til en syntax som skal funke for både Ruby 2 og 3.

Bumper to dependencies for å fikse CVE-er.