### PR TITLE
Update BouncyCastle to get rid of a Github Security warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 
-		<bouncycastle.version>1.77</bouncycastle.version>
+		<bouncycastle.version>1.78</bouncycastle.version>
 		<slf4j.version>2.0.9</slf4j.version>
 		<jaxb.version>4.0.1</jaxb.version>
 	</properties>


### PR DESCRIPTION
about DNS poisoning (https://github.com/digipost/digipost-useragreements-api-client-java/security/dependabot/35).