### PR TITLE
Upgrade deployment to Maven Central to use new plugin from Sonatype

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
 
   publish:
     needs: build
-    name: Publish ${GITHUB_REF_NAME}
+    name: Publish ${{ github.ref_name }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,66 +4,57 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         java: [ '11', '17', '21' ]
 
-    name: build java ${{ matrix.java }}
+    name: Build on Java ${{ matrix.java }}
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up java
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: "maven"
       - name: Build with Maven
-        run: mvn -B package --no-transfer-progress --file pom.xml
+        run: mvn -B verify --no-transfer-progress --show-version
 
-  makeversion:
-    if: github.ref != 'refs/heads/main'
+  publish:
     needs: build
+    name: Publish ${GITHUB_REF_NAME}
     runs-on: ubuntu-latest
-    name: Create version
-    outputs:
-      version: ${{ steps.version.outputs.version }}
     steps:
-      - name: Decide on build version
-        id: version
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Java
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: "maven"
+          gpg-private-key: ${{ secrets.MAVEN_CENTRAL_SIGNING_KEY_PRIVATE }}
+          server-id: central
+          server-username: MAVEN_CENTRAL_TOKEN_USERNAME
+          server-password: MAVEN_CENTRAL_TOKEN_PASSWORD
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Activate Artifact Signing and Version Suffix
         run: |
-          if [[ $GITHUB_REF == *"tags"* ]]; then
-            TAG=${GITHUB_REF#refs/tags/}
+          profiles="build-sources-and-javadoc,deploy-to-maven-central"
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            profiles="$profiles,sign-artifacts"
+            version_suffix=""
           else
-            TAG=${GITHUB_REF#refs/heads/}-SNAPSHOT
+            version_suffix="-SNAPSHOT"         
           fi
-          echo "version=${TAG//\//-}" >> $GITHUB_OUTPUT
-
-  deploy_snapshot:
-    if: startsWith(github.ref, 'refs/heads/')
-    needs: makeversion
-    runs-on: ubuntu-latest
-
-    name: Deploy snapshot
-    steps:
-      - uses: actions/checkout@v4
-      - uses: digipost/action-maven-publish@v1
-        with:
-          sonatype_secrets: ${{ secrets.sonatype_secrets }}
-          release_version: ${{ needs.makeversion.outputs.version }}
-          perform_release: false
-
-  release:
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    needs: makeversion
-    name: Release to Sonatype
-    steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v1
-      - name: Release to Central Repository
-        uses: digipost/action-maven-publish@v1
-        with:
-          sonatype_secrets: ${{ secrets.sonatype_secrets }}
-          release_version: ${{ needs.makeversion.outputs.version }}
-          perform_release: true
+          echo "MAVEN_PROFILES=$profiles" >> $GITHUB_ENV
+          version="${GITHUB_REF_NAME}${version_suffix}"
+          echo "VERSION=$version" >> $GITHUB_ENV
+      - name: Set Maven version
+        run: mvn --batch-mode --no-transfer-progress versions:set -DnewVersion=${VERSION}
+      - name: Build and deploy to Maven Central
+        run: |
+          mvn --batch-mode --no-transfer-progress --activate-profiles ${MAVEN_PROFILES} deploy
+        env:
+          MAVEN_CENTRAL_TOKEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_TOKEN_USERNAME }}
+          MAVEN_CENTRAL_TOKEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_SIGNING_KEY_PASSPHRASE }}

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>no.digipost</groupId>
 		<artifactId>digipost-open-super-pom</artifactId>
-		<version>13</version>
+		<version>14</version>
 	</parent>
 
 	<artifactId>digipost-useragreements-api-client-java</artifactId>


### PR DESCRIPTION
Upgrade plugins to latest release. Rewrite the publishing job to deploy directly to Maven Central (was: using obsolete GitHub action) with new plugin configured in the parent POM and using more recent support in setup-java for deployment settings in Maven.