### PR TITLE
Get path without getting query params too

### DIFF
--- a/src/main/java/no/digipost/api/useragreements/client/filters/request/RequestToSign.java
+++ b/src/main/java/no/digipost/api/useragreements/client/filters/request/RequestToSign.java
@@ -48,8 +48,12 @@ final class RequestToSign {
 
 
 	public String getPath() {
-		String path = clientRequest.getPath();
-		return path != null ? path : "";
+		try {
+			String path = clientRequest.getUri().getPath();
+			return path != null ? path : "";
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(e.getMessage(), e);
+		}
 	}
 
 


### PR DESCRIPTION
`getPath()`directly gets the path with query params which is not the same as the old behavior